### PR TITLE
Re-enable CurrentCulture_Default_Is_Specific test on iOS CI

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/CultureInfo/CultureInfoCurrentCulture.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/CultureInfo/CultureInfoCurrentCulture.cs
@@ -46,7 +46,6 @@ namespace System.Globalization.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.OSX | TestPlatforms.iOS | TestPlatforms.MacCatalyst | TestPlatforms.tvOS)]
-        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.MacCatalyst | TestPlatforms.tvOS, "https://github.com/dotnet/runtime/issues/111501")]
         public void CurrentCulture_Default_Is_Specific()
         {
             // On OSX-like platforms, the current culture taken from default system culture should be specific.


### PR DESCRIPTION
This PR re-enables the `CurrentCulture_Default_Is_Specific` test on iOS/MacCatalyst/tvOS to check if the globalization behavior difference on iOS simulators on CI (https://github.com/dotnet/runtime/issues/111501) is still reproducing.

The test was disabled in https://github.com/dotnet/runtime/pull/111032 because `CultureInfo.CurrentCulture` was returning `en` (neutral) on CI simulators instead of `en-US` (specific) as expected. This PR removes the `SkipOnPlatform` attribute to verify if the issue persists on current CI infrastructure.

> [!NOTE]
> This content was AI/Copilot-generated.