### PR TITLE
Fix NuGet restore failures for installer tests on s390x/ppc64le

### DIFF
--- a/src/installer/tests/Directory.Build.targets
+++ b/src/installer/tests/Directory.Build.targets
@@ -101,4 +101,8 @@
           Condition="'$(IsTestProject)' == 'true'" />
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets, $(MSBuildThisFileDirectory)..))" />
+
+  <!-- Use local targeting/app host packs for test projects targeting NetCoreAppCurrent.
+       This avoids NuGet restore failures on platforms without published host packs (e.g. s390x, ppc64le). -->
+  <Import Project="$(RepositoryEngineeringDir)targetingpacks.targets" Condition="'$(TargetingpacksTargetsImported)' != 'true'" />
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/130335

## Problem

Recent Mono Linux s390x and ppc64le builds fail during NuGet restore with:
```
error NU1101: Unable to find package Microsoft.NETCore.App.Host.linux-ppc64le
error NU1101: Unable to find package Microsoft.NETCore.App.Host.linux-s390x
```

The root cause is commit 49099040a62 (PR #121072, "Move hosting tests to XUnit 3") which added unconditional `<RuntimeIdentifier>$(TargetRid)</RuntimeIdentifier>` to the installer test projects. This causes NuGet to attempt resolving `Microsoft.NETCore.App.Host.{rid}`, but those packs are only built in community-supported source-build configs and don't exist on the configured NuGet feeds.

## Fix

Import `eng/targetingpacks.targets` in `src/installer/tests/Directory.Build.targets`. This is the same mechanism that library tests already use (`src/libraries/Directory.Build.targets` line 120). It automatically:

1. Sets `UseLocalTargetingRuntimePack=true` for projects targeting `NetCoreAppCurrent`
2. Cascades to `UseLocalAppHostPack=true` and `EnableAppHostPackDownload=false`
3. Registers a `KnownAppHostPack` that includes `linux-s390x` and `linux-ppc64le` as valid RIDs

The guard condition `'$(TargetingpacksTargetsImported)' != 'true'` prevents double-importing when `UseBootstrapLayout=true` (where the parent already imports it).

## Validation

Verified NuGet restore succeeds for all three affected projects with both s390x and ppc64le RIDs:
```
dotnet restore src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.Tests.csproj /p:TargetRid=linux-s390x
dotnet restore src/installer/tests/HostActivation.Tests/HostActivation.Tests.csproj /p:TargetRid=linux-ppc64le
dotnet restore src/installer/tests/AppHost.Bundle.Tests/AppHost.Bundle.Tests.csproj /p:TargetRid=linux-s390x
```